### PR TITLE
解决JSP编译问题

### DIFF
--- a/kettle-webapp/src/main/webapp/index.jsp
+++ b/kettle-webapp/src/main/webapp/index.jsp
@@ -5,7 +5,7 @@
 	  	<title>KettleConsole</title>
 	  	<link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ext3/resources/css/ext-all.css" />
 	  	<link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ui/css/public.css" />
-		<link rel='shortcut icon' href='${pageContext.request.contextPath}/img/f1_logo_small.ico' type=‘image/x-ico’ />
+		<link rel='shortcut icon' href='${pageContext.request.contextPath}/img/f1_logo_small.ico' type='image/x-ico' />
 	</head>
 	<body>
 


### PR DESCRIPTION
在CentOS6.5+Tomcat8下，该页面因为中文逗号问题，无法编译